### PR TITLE
Adding (needed) Stratigility interface

### DIFF
--- a/src/ErrorMiddleware.php
+++ b/src/ErrorMiddleware.php
@@ -4,14 +4,13 @@ namespace Franzl\Middleware\Whoops;
 
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
-use Zend\Stratigility\ErrorMiddlewareInterface;
 
 /**
  * ErrorMiddleware class for use with Zend's Stratigility middleware pipe
  */
-class ErrorMiddleware implements ErrorMiddlewareInterface
+class ErrorMiddleware
 {
-    public function __invoke($error, Request $request, Response $response, callable $out = null)
+    public function __invoke($error, Request $request, Response $response, callable $out)
     {
         return WhoopsRunner::handle($error);
     }

--- a/src/ErrorMiddleware.php
+++ b/src/ErrorMiddleware.php
@@ -4,11 +4,12 @@ namespace Franzl\Middleware\Whoops;
 
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
+use Zend\Stratigility\ErrorMiddlewareInterface;
 
 /**
  * ErrorMiddleware class for use with Zend's Stratigility middleware pipe
  */
-class ErrorMiddleware
+class ErrorMiddleware implements ErrorMiddlewareInterface
 {
     public function __invoke($error, Request $request, Response $response, callable $out = null)
     {


### PR DESCRIPTION
The `ErrorMiddleware` (that is designed to work with Stratigility) needs to have **4 required parameters** if we want it to be detected as an error middleware by Stratigility. Otherwise, it is detected as a normal middleware and breaks.

It is because of these lines of code:

https://github.com/zendframework/zend-stratigility/blob/61adbe76af9a3a1f5d2e5df7b5182daa0cf472d4/src/Dispatch.php#L61-L70

I simply removed the "= null" from the 4th parameter to make it required.
